### PR TITLE
Set dataDir from script environment variable

### DIFF
--- a/workflow.php
+++ b/workflow.php
@@ -4,7 +4,7 @@ require 'item.php';
 
 class Workflow
 {
-    const VERSION = '710726c99b2b25f6fb9a950544f72196a19e968f';
+    const VERSION = '$Format:%H$';
     const BUNDLE = 'de.gh01.alfred.github';
     const DEFAULT_CACHE_MAX_AGE = 10;
 


### PR DESCRIPTION
The updates weren't working for me as the dataDir wasn't being created. This pull request sets the dataDir using the Alfred script environment variable 'alfred_workflow_data', This fixed the issue for me, but does mean that it will only work on Alfred v2.4+.
