### PR TITLE
Search all issues, not just open issues

### DIFF
--- a/search.php
+++ b/search.php
@@ -233,7 +233,7 @@ class Search
                     }
                     break;
                 case '#':
-                    $issues = Workflow::requestGithubApi('/repos/' . $parts[0] . '/issues?sort=updated');
+                    $issues = Workflow::requestGithubApi('/repos/' . $parts[0] . '/issues?sort=updated&state=all');
                     foreach ($issues as $issue) {
                         Workflow::addItem(Item::create()
                             ->title('#' . $issue->number)


### PR DESCRIPTION
The default search state is `open` (See https://developer.github.com/v3/issues/#parameters). If you want to also search closed issues you must set the state to `all`.