### PR TITLE
Use enterprise access token for enterprise requests

### DIFF
--- a/curl.php
+++ b/curl.php
@@ -93,7 +93,7 @@ class Curl
         $options[CURLOPT_URL] = $request->url;
         $header = array();
         $header[] = 'X-Url: ' . $request->url;
-        $header[] = 'Authorization: token ' . Workflow::getConfig('access_token');
+        $header[] = 'Authorization: token ' . Workflow::getAccessToken();
         if ($request->etag) {
             $header[] = 'If-None-Match: ' . $request->etag;
         }


### PR DESCRIPTION
curl.php was hardcoded to use the access_token config param. Changing it to instead use the helper function getAccessToken(), so it uses the enterprise token if necessary.

This resolves the issue I was having in #37 where the enterprise access token wasn't working.