### PR TITLE
Fix gist support for GH:E instances.

### DIFF
--- a/search.php
+++ b/search.php
@@ -365,7 +365,7 @@ class Search
             ->title($queryUser . ' gists')
             ->subtitle("View $queryUser's' gists")
             ->icon('gists')
-            ->arg('https://gist.github.com/' . $queryUser)
+            ->arg(Workflow::getGistUrl() . $queryUser)
             ->prio(1)
         );
     }
@@ -394,7 +394,7 @@ class Search
             ->title('my gists')
             ->subtitle('View your gists')
             ->icon('gists')
-            ->arg('https://gist.github.com/' . self::$user->login)
+            ->arg(Workflow::getGistUrl() . self::$user->login)
             ->prio(1)
         );
     }

--- a/workflow.php
+++ b/workflow.php
@@ -94,6 +94,11 @@ class Workflow
         return self::$apiUrl;
     }
 
+    public static function getGistUrl()
+    {
+        return self::$enterprise ? self::getBaseUrl() . '/gist/' : 'https://gist.github.com/';
+    }
+
     public static function setAccessToken($token)
     {
         self::setConfig(self::$enterprise ? 'enterprise_access_token' : 'access_token', $token);


### PR DESCRIPTION
On our GH:E instance, gists are located at baseUrl + "/gist/".