### PR TITLE
Require a space when searching

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -118,7 +118,7 @@
 				<key>type</key>
 				<integer>0</integer>
 				<key>withspace</key>
-				<false/>
+				<true/>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.input.scriptfilter</string>


### PR DESCRIPTION
When trying to do a query starting with “ghost”, it triggered this workflow requiring that I had to hold down ctrl to use the default fallback. Since all queries through this workflow tend to have a space anyways (“gh “), it would make things less confusing to just mark that from the info.plist directly.