### PR TITLE
Fix sorting for repo sub commands

### DIFF
--- a/search.php
+++ b/search.php
@@ -364,6 +364,7 @@ class Search
                             ->subtitle($commit->commit->author->date.'  ('.$commit->sha.')')
                             ->icon('commits')
                             ->arg('https://github.com/'.$parts[0].'/commit/'.$commit->sha)
+                            ->prio(strtotime($commit->commit->author->date))
                         );
                     }
                     break;
@@ -403,6 +404,7 @@ class Search
                             ->subtitle($issue->title)
                             ->icon($issue->pull_request ? 'pull-request' : 'issue')
                             ->arg($issue->html_url)
+                            ->prio(strtotime($issue->updated_at))
                         );
                     }
                     break;


### PR DESCRIPTION
Use `issue->updated_at` and `commit->commit->author->date` for setting
priority on items so that the most recent commits and most recently
updated issues appear first in the workflow results.

I haven't been able to make use of the `#` or `*` repo sub-commands, since the call to [`Workflow::sortItems()`](https://github.com/gharlan/alfred-github-workflow/blob/9890ff58edfabb83c131854f9ab4d91feee0b8c8/search.php#L89) re-orders the results from github based on their text.

Screenshots:

**Before:** list of issues

![screen shot 2016-12-19 at 12 42 12 pm](https://cloud.githubusercontent.com/assets/993340/21328698/0c5f3350-c5ea-11e6-8ead-72475073ec16.png)

**After:** list of issues

![screen shot 2016-12-19 at 12 51 35 pm](https://cloud.githubusercontent.com/assets/993340/21328707/138d7e84-c5ea-11e6-8fa5-36e00e830c11.png)

**Before:** list of commits

![screen shot 2016-12-19 at 12 51 58 pm](https://cloud.githubusercontent.com/assets/993340/21328714/1c851a88-c5ea-11e6-8cf0-8a12a65eb67a.png)

**After:** list of commits

![screen shot 2016-12-19 at 12 51 41 pm](https://cloud.githubusercontent.com/assets/993340/21328725/23170e56-c5ea-11e6-8f98-ec67feef3af9.png)
