### PR TITLE
Land on issue templates by default

### DIFF
--- a/search.php
+++ b/search.php
@@ -435,7 +435,7 @@ class Search
                 ->title($parts[0].' new issue')
                 ->subtitle('Create new issue')
                 ->icon('issue')
-                ->arg('/'.$parts[0].'/issues/new?source=c')
+                ->arg('/'.$parts[0].'/issues/new/choose?source=c')
             );
             Workflow::addItem(Item::create()
                 ->title($parts[0].' new pull')


### PR DESCRIPTION
Currently, when I uses the command `gh {user}/{repo} new issue` if the repo has issue templates set up, I will not see these as I automatically skip that step and drop right onto the new issue page with no template.

This change makes it so that I will first land on the template selector page. If the repo has no templates set up, then the `issues/new/choose` path will automatically resolve to `issues/new` so there is no regression in existing behavior here.