### PR TITLE
Fix result display for non-PR issue IDs

### DIFF
--- a/search.php
+++ b/search.php
@@ -402,7 +402,7 @@ class Search
                             ->title('#'.$issue->number)
                             ->comparator($parts[0].' #'.$issue->number)
                             ->subtitle($issue->title)
-                            ->icon($issue->pull_request ? 'pull-request' : 'issue')
+                            ->icon(isset($issue->pull_request) ? 'pull-request' : 'issue')
                             ->arg($issue->html_url)
                             ->prio(strtotime($issue->updated_at))
                         );


### PR DESCRIPTION
The `$issue` stdClass does not (no longer?) have the `pull_request` property if the given identifier is a regular issue and not a pull request. Wrap in `isset()` to prevent the error `Warning: Undefined property: stdClass::$pull_request in .../search.php on line 405`. Fixes #129