### PR TITLE
Update my stars URL

### DIFF
--- a/search.php
+++ b/search.php
@@ -557,7 +557,6 @@ class Search
             'dashboard' => ['', 'View your dashboard'],
             'pulls ' => ['pulls', 'View your pull requests', 'pull-request'],
             'issues ' => ['issues', 'View your issues', 'issue'],
-            'stars' => ['stars', 'View your starred repositories'],
             'profile' => [self::$user->login, 'View your public user profile', 'user'],
             'settings' => ['settings', 'View or edit your account settings'],
             'notifications' => ['notifications', 'View all your notifications'],
@@ -579,6 +578,13 @@ class Search
             ->prio(1)
         );
 
+        Workflow::addItemIfMatches(Item::create()
+            ->title('my stars')
+            ->subtitle('View your stars')
+            ->icon('stars')
+            ->arg('/'.self::$user->login.'?tab=stars')
+            ->prio(1)
+        );
         Workflow::addItemIfMatches(Item::create()
             ->title('my repos ')
             ->subtitle('View your repos')


### PR DESCRIPTION
Thanks for the amazing work 💙

I think `https://github.com/<username>?tab=stars` is a better default page for viewing my starred repos due to

* it supports new feature i.e. star by category
* it includes all old features (search, filter, sort etc) the old starred page has

|old|new|
|---|---|
|<img width="673" alt="Screen Shot 2023-04-02 at 11 02 07 AM" src="https://user-images.githubusercontent.com/90570853/229370719-fda89f59-263f-4105-a7fa-3215fd3f621e.png">|<img width="634" alt="Screen Shot 2023-04-02 at 11 02 22 AM" src="https://user-images.githubusercontent.com/90570853/229370721-b3df3743-fa7c-4c50-8542-5ee5f400749d.png">|
