### PR TITLE
Escape ANSI escape codes in item titles

### DIFF
--- a/item.php
+++ b/item.php
@@ -171,9 +171,10 @@ class Item
                 $c->addAttribute('valid', 'no');
                 $title .= $item->add;
             }
-            $c->addChild('title', htmlspecialchars($title));
+            $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_DISALLOWED | ENT_XML1;
+            $c->addChild('title', htmlspecialchars($title, $flags));
             if ($item->subtitle) {
-                $c->addChild('subtitle', htmlspecialchars($item->subtitle));
+                $c->addChild('subtitle', htmlspecialchars($item->subtitle, $flags));
             }
         }
 


### PR DESCRIPTION
# Problem

The query `gh neovim/neovim *13748512f6d6dfb5895c2233d2e07480e00eb753` fails, resulting in the following debug output:

```
[17:44:55.128] ERROR: GitHub[Script Filter] JSON error: JSON text did not start with array or object and option to allow fragments not set. around line 1, column 0. in JSON:
Warning: SimpleXMLElement::asXML(): xmlEscapeEntities : char out of range in /Users/marcus/scratch/alfred-github-workflow/item.php on line 180

Call Stack:
    0.0001     470384   1. {main}() /Users/marcus/Library/Caches/com.runningwithcrayons.Alfred/Workflow Scripts/CAB4005A-B683-4894-B7FE-C0FC851E9BD5:0
    1.3125   34736456   2. Workflow::getItemsAsXml() /Users/marcus/Library/Caches/com.runningwithcrayons.Alfred/Workflow Scripts/CAB4005A-B683-4894-B7FE-C0FC851E9BD5:7
    1.3125   34736456   3. Item::toXml($items = [0 => class Item { private $randomUid = FALSE; private $prefix = ''; private $prefixOnlyTitle = TRUE; private $title = 'test(busted): disable colors in test-runner output #15610\n\nProblem\r\n-------\r\n\r\nBecause test/busted/outputHandlers/nvim.lua doesn\'t know if it\'s running\r\nin a terminal (no "isatty" equivalent), it outputs color codes in CI\r\nlogs and local tooling that runs the tests in a pipe:\r\n\r\n    [1m\033[33m[ SKIPPED ]\033[0m\033[0m \033[36m\r\n\r\nThis is just noise, hard for humans to read.\r\n\r\nSolution\r\n--------\r\n\r\nDisable the color codes. If we later find a clever way to detect\r\na terminal in nvim.lua, we might consider re-enabling c'...; private $comparator = 'neovim/neovim *13748512f6d6dfb5895c2233d2e07480e00eb753'; private $subtitle = '2021-09-09T16:18:43Z  (13748512f6d6dfb5895c2233d2e07480e00eb753)'; private $icon = 'commits'; private $arg = '/neovim/neovim/commit/13748512f6d6dfb5895c2233d2e07480e00eb753'; private $valid = TRUE; private $add = '…'; private $autocomplete = TRUE; private $prio = 1631204323; private $missingChars = 0; private $sameChars = 55 }, 1 => class Item { private $randomUid = FALSE; private $prefix = ''; private $prefixOnlyTitle = TRUE; private $title = 'Search \'neovim/neovim\' for \'*13748512f6d6dfb5895c2233d2e07480e00eb753\''; private $comparator = NULL; private $subtitle = NULL; private $icon = 'search'; private $arg = '/neovim/neovim/search?q=%2A13748512f6d6dfb5895c2233d2e07480e00eb753'; private $valid = TRUE; private $add = '…'; private $autocomplete = FALSE; private $prio = 0; private $missingChars = 0; private $sameChars = 0 }, 2 => class Item { private $randomUid = FALSE; private $prefix = ''; private $prefixOnlyTitle = TRUE; private $title = 'Search GitHub for \'neovim/neovim *13748512f6d6dfb5895c2233d2e07480e00eb753\''; private $comparator = NULL; private $subtitle = NULL; private $icon = 'search'; private $arg = '/search?q=neovim%2Fneovim+%2A13748512f6d6dfb5895c2233d2e07480e00eb753'; private $valid = TRUE; private $add = '…'; private $autocomplete = FALSE; private $prio = 0; private $missingChars = 0; private $sameChars = 0 }], $enterprise = FALSE, $hotkey = '0', $baseUrl = 'https://github.com') /Users/marcus/scratch/alfred-github-workflow/workflow.php:426
    1.3127   34737016   4. SimpleXMLElement->asXML() /Users/marcus/scratch/alfred-github-workflow/item.php:180
```

The issue is that the commit message for  https://github.com/neovim/neovim/commit/13748512f6d6dfb5895c2233d2e07480e00eb753 contains ANSI escape codes.

# Solution

Pass the `ENT_DISALLOWED` flag to [htmlspecialchars](https://www.php.net/manual/en/function.htmlspecialchars.php). Described as
>Replace invalid code points for the given document type with a Unicode Replacement Character U+FFFD (UTF-8) or &#xFFFD; (otherwise) instead of leaving them as is. This may be useful, for instance, to ensure the well-formedness of XML documents with embedded external content.

`ENT_QUOTES` and `ENT_SUBSTITUTE` are the default flags so these are not actually new flags. 

I've also passed `ENT_XML1` because it just feels right tbh.