### PR TITLE
Add PHPUnit test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,29 @@ jobs:
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --no-progress
+
+  phpunit:
+    name: phpunit (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.2', '8.3', '8.4', '8.5', '8.6']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,6 +14,7 @@ return (new PhpCsFixer\Config())
         'empty_loop_body' => ['style' => 'semicolon'],
         'method_argument_space' => false,
         'native_constant_invocation' => false,
+        'no_null_property_initialization' => false,
         'phpdoc_align' => false,
         'phpdoc_line_span' => [
             'class' => 'single',

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "require-dev": {
         "ext-imagick": "*",
         "friendsofphp/php-cs-fixer": "^3.95.1",
-        "phpstan/phpstan": "^2.1.54"
+        "phpstan/phpstan": "^2.1.54",
+        "phpunit/phpunit": "^11.5.55"
     },
     "config": {
         "platform": {
@@ -28,6 +29,7 @@
         "phpstan:no-cache": [
             "phpstan clear-result-cache --no-interaction",
             "phpstan analyse -v"
-        ]
+        ],
+        "phpunit": "phpunit"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a263a06c5b8320a66667a97415132a9e",
+    "content-hash": "31c559dbc4629d81bd63bdf7f08ebd50",
     "packages": [],
     "packages-dev": [
         {
@@ -576,6 +576,242 @@
             "time": "2026-04-12T17:00:09+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "2.1.54",
             "dist": {
@@ -627,6 +863,463 @@
                 }
             ],
             "time": "2026-04-29T13:31:09+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
         },
         {
             "name": "psr/container",
@@ -1308,6 +2001,326 @@
             "time": "2024-06-11T12:45:25+00:00"
         },
         {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
             "name": "sebastian/diff",
             "version": "6.0.2",
             "source": {
@@ -1373,6 +2386,657 @@
                 }
             ],
             "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/console",
@@ -2804,6 +4468,56 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -5,3 +5,4 @@ parameters:
         - bin
         - bin/build
         - src
+        - tests

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheDirectory=".cache/phpunit"
+    failOnWarning="true"
+    failOnNotice="true"
+    failOnDeprecation="true"
+    failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/workflow.php
+++ b/src/workflow.php
@@ -1,7 +1,7 @@
 <?php
 
-require __DIR__ . '/item.php';
-require __DIR__ . '/fetcher.php';
+require_once __DIR__ . '/item.php';
+require_once __DIR__ . '/fetcher.php';
 
 final class Workflow
 {

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -1,0 +1,227 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class CurlTest extends HttpServerTestCase
+{
+    protected static function routerPath(): string
+    {
+        return __DIR__ . '/fixtures/curl-server.php';
+    }
+
+    #[DataProvider('dataGetHeader')]
+    public function testGetHeader(string $headers, string $key, ?string $expected): void
+    {
+        self::assertSame($expected, Curl::getHeader($headers, $key));
+    }
+
+    /** @return iterable<string, array{string, string, ?string}> */
+    public static function dataGetHeader(): iterable
+    {
+        yield 'simple header' => [
+            "Content-Type: text/plain\r\n",
+            'Content-Type',
+            'text/plain',
+        ];
+        yield 'key match is case-insensitive' => [
+            "content-type: foo\r\n",
+            'Content-Type',
+            'foo',
+        ];
+        yield 'finds header among many' => [
+            "Foo: 1\r\nBar: 2\r\nBaz: 3\r\n",
+            'Bar',
+            '2',
+        ];
+        yield 'value preserves inner spaces' => [
+            "Link: <https://api.example.com/x?page=2>; rel=\"next\"\r\n",
+            'Link',
+            '<https://api.example.com/x?page=2>; rel="next"',
+        ];
+        yield 'returns null when missing' => [
+            "Foo: 1\r\n",
+            'Bar',
+            null,
+        ];
+        yield 'returns first occurrence on duplicate' => [
+            "X: first\r\nX: second\r\n",
+            'X',
+            'first',
+        ];
+        yield 'empty header string returns null' => [
+            '',
+            'X',
+            null,
+        ];
+        yield 'value stops at line break' => [
+            "ETag: \"abc\"\r\nNext: ignored\r\n",
+            'ETag',
+            '"abc"',
+        ];
+    }
+
+    public function testExecuteFetchesBodyStatusAndResponseHeaders(): void
+    {
+        /** @var list<CurlResponse> $received */
+        $received = [];
+        $request = new CurlRequest(
+            self::baseUrl() . '/hello',
+            null,
+            null,
+            static function (CurlResponse $r) use (&$received): void {
+                $received[] = $r;
+            },
+        );
+        $curl = new Curl();
+        $curl->add($request);
+        self::assertTrue($curl->execute());
+
+        self::assertCount(1, $received);
+        $response = $received[0];
+
+        self::assertSame(200, $response->status);
+        self::assertSame('Hello, World!', $response->content);
+        self::assertSame('"etag-hello"', $response->etag);
+        self::assertNotNull($response->contentType);
+        self::assertStringStartsWith('text/plain', $response->contentType);
+        self::assertSame('<https://example.com/next>; rel="next"', $response->link);
+        self::assertSame($request, $response->request);
+    }
+
+    public function testExecuteSendsAuthorizationTokenAndUserAgent(): void
+    {
+        /** @var list<CurlResponse> $received */
+        $received = [];
+        $curl = new Curl();
+        $curl->add(new CurlRequest(
+            self::baseUrl() . '/echo-headers',
+            null,
+            'secret-token',
+            static function (CurlResponse $r) use (&$received): void {
+                $received[] = $r;
+            },
+        ));
+        $curl->execute();
+
+        self::assertCount(1, $received);
+        self::assertNotNull($received[0]->content);
+        $body = json_decode($received[0]->content, true);
+        self::assertIsArray($body);
+        self::assertSame('token secret-token', $body['authorization']);
+        self::assertSame('alfred-github-workflow', $body['user-agent']);
+        self::assertSame(self::baseUrl() . '/echo-headers', $body['x-url']);
+    }
+
+    public function testExecuteOmitsAuthorizationHeaderWhenTokenIsNull(): void
+    {
+        /** @var list<CurlResponse> $received */
+        $received = [];
+        $curl = new Curl();
+        $curl->add(new CurlRequest(
+            self::baseUrl() . '/echo-headers',
+            null,
+            null,
+            static function (CurlResponse $r) use (&$received): void {
+                $received[] = $r;
+            },
+        ));
+        $curl->execute();
+
+        self::assertNotNull($received[0]->content);
+        $body = json_decode($received[0]->content, true);
+        self::assertIsArray($body);
+        self::assertSame('', $body['authorization']);
+    }
+
+    public function testExecuteSendsIfNoneMatchAndHandles304(): void
+    {
+        /** @var list<CurlResponse> $received */
+        $received = [];
+        $curl = new Curl();
+        $curl->add(new CurlRequest(
+            self::baseUrl() . '/etag',
+            '"v1"',
+            null,
+            static function (CurlResponse $r) use (&$received): void {
+                $received[] = $r;
+            },
+        ));
+        $curl->execute();
+
+        self::assertCount(1, $received);
+        self::assertSame(304, $received[0]->status);
+        self::assertNull($received[0]->content);
+        self::assertSame('"v1"', $received[0]->etag);
+    }
+
+    public function testExecuteFetchesFreshContentWhenEtagDoesNotMatch(): void
+    {
+        /** @var list<CurlResponse> $received */
+        $received = [];
+        $curl = new Curl();
+        $curl->add(new CurlRequest(
+            self::baseUrl() . '/etag',
+            '"stale"',
+            null,
+            static function (CurlResponse $r) use (&$received): void {
+                $received[] = $r;
+            },
+        ));
+        $curl->execute();
+
+        self::assertSame(200, $received[0]->status);
+        self::assertSame('fresh content', $received[0]->content);
+        self::assertSame('"v1"', $received[0]->etag);
+    }
+
+    public function testExecuteDoesNotStoreContentForNon200Status(): void
+    {
+        /** @var list<CurlResponse> $received */
+        $received = [];
+        $curl = new Curl();
+        $curl->add(new CurlRequest(
+            self::baseUrl() . '/server-error',
+            null,
+            null,
+            static function (CurlResponse $r) use (&$received): void {
+                $received[] = $r;
+            },
+        ));
+        $curl->execute();
+
+        self::assertSame(500, $received[0]->status);
+        self::assertNull($received[0]->content);
+    }
+
+    public function testExecuteRunsRequestsInParallel(): void
+    {
+        /** @var array<string, string> $bodies */
+        $bodies = [];
+        $curl = new Curl();
+        $ids = ['a', 'b', 'c', 'd', 'e'];
+        foreach ($ids as $id) {
+            $curl->add(new CurlRequest(
+                self::baseUrl() . '/echo-id?id=' . $id,
+                null,
+                null,
+                static function (CurlResponse $r) use (&$bodies, $id): void {
+                    $bodies[$id] = (string) $r->content;
+                },
+            ));
+        }
+
+        $start = microtime(true);
+        $curl->execute();
+        $elapsed = microtime(true) - $start;
+
+        // Order of arrival depends on parallel completion; normalize before comparing.
+        ksort($bodies);
+        self::assertSame(
+            ['a' => 'id-a', 'b' => 'id-b', 'c' => 'id-c', 'd' => 'id-d', 'e' => 'id-e'],
+            $bodies,
+        );
+        // Each request sleeps 20ms server-side. Sequential = ~100ms; parallel ≈ ~20-40ms.
+        // Allow a generous ceiling of 80ms so we still catch a regression to sequential.
+        self::assertLessThan(0.08, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.08s");
+    }
+}

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -220,8 +220,8 @@ final class CurlTest extends HttpServerTestCase
             ['a' => 'id-a', 'b' => 'id-b', 'c' => 'id-c', 'd' => 'id-d', 'e' => 'id-e'],
             $bodies,
         );
-        // Each request sleeps 20ms server-side. Sequential = ~100ms; parallel ≈ ~20-40ms.
-        // Allow a generous ceiling of 80ms so we still catch a regression to sequential.
-        self::assertLessThan(0.08, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.08s");
+        // Each request sleeps 100ms server-side. Sequential = ~500ms; parallel ≈ ~200ms.
+        // 350ms ceiling tolerates noisy CI runners while still catching a regression to sequential.
+        self::assertLessThan(0.35, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.35s");
     }
 }

--- a/tests/CurlTest.php
+++ b/tests/CurlTest.php
@@ -193,13 +193,15 @@ final class CurlTest extends HttpServerTestCase
         self::assertNull($received[0]->content);
     }
 
-    public function testExecuteRunsRequestsInParallel(): void
+    public function testExecuteRunsMultipleRequestsThroughCurlMulti(): void
     {
+        // 5 requests through one Curl instance. Parallelism is structural (curl_multi_*) — we
+        // assert correctness rather than timing, since CI runners' worker scheduling is too
+        // noisy to derive a stable wall-clock threshold.
         /** @var array<string, string> $bodies */
         $bodies = [];
         $curl = new Curl();
-        $ids = ['a', 'b', 'c', 'd', 'e'];
-        foreach ($ids as $id) {
+        foreach (['a', 'b', 'c', 'd', 'e'] as $id) {
             $curl->add(new CurlRequest(
                 self::baseUrl() . '/echo-id?id=' . $id,
                 null,
@@ -209,19 +211,13 @@ final class CurlTest extends HttpServerTestCase
                 },
             ));
         }
-
-        $start = microtime(true);
         $curl->execute();
-        $elapsed = microtime(true) - $start;
 
-        // Order of arrival depends on parallel completion; normalize before comparing.
+        // Order of arrival depends on completion timing; normalize before comparing.
         ksort($bodies);
         self::assertSame(
             ['a' => 'id-a', 'b' => 'id-b', 'c' => 'id-c', 'd' => 'id-d', 'e' => 'id-e'],
             $bodies,
         );
-        // Each request sleeps 100ms server-side. Sequential = ~500ms; parallel ≈ ~200ms.
-        // 350ms ceiling tolerates noisy CI runners while still catching a regression to sequential.
-        self::assertLessThan(0.35, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.35s");
     }
 }

--- a/tests/FetcherTest.php
+++ b/tests/FetcherTest.php
@@ -1,0 +1,279 @@
+<?php
+
+final class FetcherTest extends HttpServerTestCase
+{
+    private static string $tmpDir = '';
+    private static string $hitsFile = '';
+
+    protected static function routerPath(): string
+    {
+        return __DIR__ . '/fixtures/fetcher-server.php';
+    }
+
+    protected static function serverEnv(): array
+    {
+        return ['FETCHER_HITS_FILE' => self::$hitsFile];
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$tmpDir = sys_get_temp_dir() . '/agw-fetcher-test-' . bin2hex(random_bytes(6));
+        mkdir(self::$tmpDir, 0o755, true);
+        putenv('alfred_workflow_data=' . self::$tmpDir);
+
+        Workflow::init();
+
+        self::$hitsFile = self::$tmpDir . '/hits.log';
+
+        parent::setUpBeforeClass();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        // Avoid the Workflow shutdown handler firing background-refresh subprocesses on PHP exit.
+        self::clearRefreshUrls();
+
+        if (is_dir(self::$tmpDir)) {
+            $files = glob(self::$tmpDir . '/*') ?: [];
+            foreach ($files as $f) {
+                if (is_file($f)) {
+                    @unlink($f);
+                }
+            }
+            @rmdir(self::$tmpDir);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        Workflow::deleteCache();
+        file_put_contents(self::$hitsFile, '');
+        self::clearRefreshUrls();
+    }
+
+    private static function clearRefreshUrls(): void
+    {
+        $prop = new ReflectionProperty(Workflow::class, 'refreshUrls');
+        $prop->setValue(null, []);
+    }
+
+    private function totalHits(): int
+    {
+        $contents = file_get_contents(self::$hitsFile);
+        if (false === $contents || '' === $contents) {
+            return 0;
+        }
+
+        return substr_count($contents, "\n");
+    }
+
+    public function testRequestUrlFetchesAndCachesJson(): void
+    {
+        $url = self::baseUrl() . '/json?id=hello';
+
+        $first = Fetcher::requestUrl($url);
+        self::assertInstanceOf(stdClass::class, $first);
+        self::assertSame('hello', $first->id);
+        self::assertSame('val-hello', $first->value);
+        self::assertSame(1, $this->totalHits());
+
+        // Second call within maxAge window: served from cache, no HTTP roundtrip.
+        $second = Fetcher::requestUrl($url);
+        self::assertInstanceOf(stdClass::class, $second);
+        self::assertSame('hello', $second->id);
+        self::assertSame(1, $this->totalHits());
+    }
+
+    public function testRequestUrlFollowsPaginationViaLinkHeader(): void
+    {
+        $url = self::baseUrl() . '/paginated?p=1';
+
+        $merged = Fetcher::requestUrl($url);
+        self::assertIsArray($merged);
+        self::assertCount(6, $merged);
+        self::assertSame(1, $merged[0]->page);
+        self::assertSame(3, $merged[5]->page);
+        self::assertSame(3, $this->totalHits());
+
+        // Re-request: full chain served from cache via parent linkage, no extra hits.
+        $cached = Fetcher::requestUrl($url);
+        self::assertCount(6, $cached);
+        self::assertSame(3, $this->totalHits());
+    }
+
+    public function testRequestUrlFirstPageOnlyStopsAfterOneRequest(): void
+    {
+        $first = Fetcher::requestUrl(
+            self::baseUrl() . '/paginated?p=1',
+            new FetchOptions(firstPageOnly: true),
+        );
+
+        self::assertIsArray($first);
+        self::assertCount(2, $first);
+        self::assertSame(1, $first[0]->page);
+        self::assertSame(1, $this->totalHits());
+    }
+
+    public function testRequestUrlNonOkDeletesCacheRow(): void
+    {
+        $url = self::baseUrl() . '/error500';
+
+        // Pre-populate so we can observe deletion.
+        Workflow::getStatement('REPLACE INTO request_cache VALUES(?, ?, ?, ?, 0, NULL)')
+            ->execute([$url, time() - 3600, '"x"', json_encode(['x' => 1])]);
+
+        $result = Fetcher::requestUrl($url, new FetchOptions(refreshInBackground: false));
+        self::assertSame([], $result);
+
+        $stmt = Workflow::getStatement('SELECT 1 FROM request_cache WHERE url = ?');
+        $stmt->execute([$url]);
+        self::assertFalse($stmt->fetchColumn());
+    }
+
+    public function testRequestUrlReusesCachedContentOn304(): void
+    {
+        $url = self::baseUrl() . '/etag?v=v1';
+
+        Fetcher::requestUrl($url);
+        self::assertSame(1, $this->totalHits());
+
+        // Make stale; refreshInBackground=false forces a synchronous live fetch.
+        Workflow::getStatement('UPDATE request_cache SET timestamp = ? WHERE url = ?')
+            ->execute([time() - 3600, $url]);
+
+        $second = Fetcher::requestUrl($url, new FetchOptions(refreshInBackground: false));
+        self::assertSame('v1', $second->value);
+        self::assertSame(2, $this->totalHits());
+    }
+
+    public function testRequestUrlStaleWithBackgroundRefreshServesCacheAndMarksUrl(): void
+    {
+        $url = self::baseUrl() . '/json?id=stale';
+
+        Fetcher::requestUrl($url);
+        self::assertSame(1, $this->totalHits());
+
+        // Force stale + outside the 3-minute background-refresh debounce.
+        Workflow::getStatement('UPDATE request_cache SET timestamp = ?, refresh = ? WHERE url = ?')
+            ->execute([time() - 3600, time() - 3600, $url]);
+
+        $cached = Fetcher::requestUrl($url);
+        // Stale-while-revalidate: cached content served, no live fetch.
+        self::assertSame(1, $this->totalHits());
+        self::assertInstanceOf(stdClass::class, $cached);
+        self::assertSame('stale', $cached->id);
+
+        $prop = new ReflectionProperty(Workflow::class, 'refreshUrls');
+        $refreshUrls = $prop->getValue();
+        self::assertIsArray($refreshUrls);
+        self::assertArrayHasKey($url, $refreshUrls);
+    }
+
+    public function testRequestUrlUnwrapsItemsKey(): void
+    {
+        $result = Fetcher::requestUrl(self::baseUrl() . '/items-wrapper');
+
+        self::assertIsArray($result);
+        self::assertCount(2, $result);
+        self::assertSame('one', $result[0]->name);
+        self::assertSame('two', $result[1]->name);
+    }
+
+    public function testRequestUrlAppliesFieldWhitelist(): void
+    {
+        $options = new FetchOptions(fields: [
+            'sha',
+            'commit' => ['author' => ['date']],
+        ]);
+
+        $result = Fetcher::requestUrl(self::baseUrl() . '/picky', $options);
+
+        self::assertInstanceOf(stdClass::class, $result);
+        self::assertSame('abc', $result->sha);
+        self::assertObjectNotHasProperty('extra', $result);
+        self::assertObjectNotHasProperty('message', $result);
+        self::assertInstanceOf(stdClass::class, $result->commit);
+        self::assertInstanceOf(stdClass::class, $result->commit->author);
+        self::assertSame('2024-01-01', $result->commit->author->date);
+        self::assertObjectNotHasProperty('name', $result->commit->author);
+    }
+
+    public function testRequestUrlReencodesNonJsonResponse(): void
+    {
+        $result = Fetcher::requestUrl(self::baseUrl() . '/non-json');
+
+        self::assertSame('Hello, World!', $result);
+    }
+
+    public function testRequestRawReturnsBodyAndDoesNotCache(): void
+    {
+        $url = self::baseUrl() . '/non-json';
+        $body = Fetcher::requestRaw($url);
+
+        self::assertSame('Hello, World!', $body);
+
+        $stmt = Workflow::getStatement('SELECT 1 FROM request_cache WHERE url = ?');
+        $stmt->execute([$url]);
+        self::assertFalse($stmt->fetchColumn());
+    }
+
+    public function testStreamUrlYieldsEachItemFromCacheChain(): void
+    {
+        $url = self::baseUrl() . '/paginated?p=1';
+        Fetcher::requestUrl($url);
+        $hitsBefore = $this->totalHits();
+
+        $items = iterator_to_array(Fetcher::streamUrl($url), false);
+
+        self::assertCount(6, $items);
+        self::assertSame(1, $items[0]->page);
+        self::assertSame(1, $items[0]->item);
+        self::assertSame(3, $items[5]->page);
+        self::assertSame(6, $items[5]->item);
+        // Walks cache only — no fresh HTTP.
+        self::assertSame($hitsBefore, $this->totalHits());
+    }
+
+    public function testStreamUrlFirstPageOnlyStopsAtFirstPage(): void
+    {
+        $url = self::baseUrl() . '/paginated?p=1';
+        Fetcher::requestUrl($url);
+
+        $items = iterator_to_array(
+            Fetcher::streamUrl($url, new FetchOptions(firstPageOnly: true)),
+            false,
+        );
+
+        self::assertCount(2, $items);
+        self::assertSame(1, $items[0]->page);
+    }
+
+    public function testQueueRunFetchesInParallel(): void
+    {
+        /** @var array<string, mixed> $bodies */
+        $bodies = [];
+        $f = new Fetcher();
+        foreach (['a', 'b', 'c', 'd', 'e'] as $id) {
+            $f->queueUrl(
+                self::baseUrl() . '/slow?id=' . $id,
+                static function ($r) use (&$bodies, $id): void {
+                    $bodies[$id] = $r instanceof stdClass ? $r->id : null;
+                },
+            );
+        }
+
+        $start = microtime(true);
+        $f->run();
+        $elapsed = microtime(true) - $start;
+
+        ksort($bodies);
+        self::assertSame(
+            ['a' => 'a', 'b' => 'b', 'c' => 'c', 'd' => 'd', 'e' => 'e'],
+            $bodies,
+        );
+        // Each request sleeps 20ms server-side. Sequential = ~100ms; parallel ≈ ~20-40ms.
+        self::assertLessThan(0.08, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.08s");
+    }
+}

--- a/tests/FetcherTest.php
+++ b/tests/FetcherTest.php
@@ -250,8 +250,11 @@ final class FetcherTest extends HttpServerTestCase
         self::assertSame(1, $items[0]->page);
     }
 
-    public function testQueueRunFetchesInParallel(): void
+    public function testQueueRunDispatchesAllRequests(): void
     {
+        // 5 requests through one Fetcher. Parallelism is structural (curl_multi_* under the
+        // hood) — we assert correctness rather than timing, since CI runners' worker scheduling
+        // is too noisy to derive a stable wall-clock threshold.
         /** @var array<string, mixed> $bodies */
         $bodies = [];
         $f = new Fetcher();
@@ -263,18 +266,12 @@ final class FetcherTest extends HttpServerTestCase
                 },
             );
         }
-
-        $start = microtime(true);
         $f->run();
-        $elapsed = microtime(true) - $start;
 
         ksort($bodies);
         self::assertSame(
             ['a' => 'a', 'b' => 'b', 'c' => 'c', 'd' => 'd', 'e' => 'e'],
             $bodies,
         );
-        // Each request sleeps 100ms server-side. Sequential = ~500ms; parallel ≈ ~200ms.
-        // 350ms ceiling tolerates noisy CI runners while still catching a regression to sequential.
-        self::assertLessThan(0.35, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.35s");
     }
 }

--- a/tests/FetcherTest.php
+++ b/tests/FetcherTest.php
@@ -273,7 +273,8 @@ final class FetcherTest extends HttpServerTestCase
             ['a' => 'a', 'b' => 'b', 'c' => 'c', 'd' => 'd', 'e' => 'e'],
             $bodies,
         );
-        // Each request sleeps 20ms server-side. Sequential = ~100ms; parallel ≈ ~20-40ms.
-        self::assertLessThan(0.08, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.08s");
+        // Each request sleeps 100ms server-side. Sequential = ~500ms; parallel ≈ ~200ms.
+        // 350ms ceiling tolerates noisy CI runners while still catching a regression to sequential.
+        self::assertLessThan(0.35, $elapsed, "5 parallel requests took {$elapsed}s, expected < 0.35s");
     }
 }

--- a/tests/HttpServerTestCase.php
+++ b/tests/HttpServerTestCase.php
@@ -1,0 +1,94 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+abstract class HttpServerTestCase extends TestCase
+{
+    private static string $baseUrl = '';
+
+    /** @var resource|null */
+    private static $serverProcess = null;
+
+    /** Absolute path to the PHP router script that handles incoming requests. */
+    abstract protected static function routerPath(): string;
+
+    /**
+     * Extra env variables to pass to the test server process.
+     *
+     * @return array<string, string>
+     */
+    protected static function serverEnv(): array
+    {
+        return [];
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        $port = self::findFreePort();
+        self::$baseUrl = 'http://127.0.0.1:' . $port;
+
+        $cmd = sprintf(
+            'exec php -S 127.0.0.1:%d %s',
+            $port,
+            escapeshellarg(static::routerPath()),
+        );
+        $env = ['PHP_CLI_SERVER_WORKERS' => '4'] + static::serverEnv() + getenv();
+
+        $process = proc_open(
+            $cmd,
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            null,
+            $env,
+        );
+        if (!is_resource($process)) {
+            self::fail('failed to spawn test server');
+        }
+        self::$serverProcess = $process;
+
+        for ($i = 0; $i < 100; ++$i) {
+            $sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
+            if (false !== $sock) {
+                fclose($sock);
+
+                return;
+            }
+            usleep(50_000);
+        }
+        self::fail('test server did not start within 5 seconds');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (is_resource(self::$serverProcess)) {
+            proc_terminate(self::$serverProcess);
+            proc_close(self::$serverProcess);
+            self::$serverProcess = null;
+        }
+    }
+
+    protected static function baseUrl(): string
+    {
+        return self::$baseUrl;
+    }
+
+    private static function findFreePort(): int
+    {
+        $sock = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if (false === $sock) {
+            self::fail("could not allocate test port: $errstr");
+        }
+        $name = stream_socket_get_name($sock, false);
+        if (false === $name) {
+            fclose($sock);
+            self::fail('could not read socket name');
+        }
+        fclose($sock);
+
+        return (int) substr($name, strrpos($name, ':') + 1);
+    }
+}

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,0 +1,248 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ItemTest extends TestCase
+{
+    #[DataProvider('dataMatch')]
+    public function testMatch(Item $item, string $query, bool $expected): void
+    {
+        self::assertSame($expected, $item->match($query));
+    }
+
+    /** @return iterable<string, array{Item, string, bool}> */
+    public static function dataMatch(): iterable
+    {
+        $repo = static fn () => Item::create()->title('user/repo');
+
+        yield 'subsequence usr' => [$repo(), 'usr', true];
+        yield 'full prefix' => [$repo(), 'user', true];
+        yield 'spans separator' => [$repo(), 'u/r', true];
+        yield 'missing chars' => [$repo(), 'xyz', false];
+        yield 'trailing extra char' => [$repo(), 'repo!', false];
+        yield 'uppercase query, mixed-case title' => [Item::create()->title('User/Repo'), 'USER', true];
+        yield 'mixed-case query, mixed-case title' => [Item::create()->title('User/Repo'), 'uSeR', true];
+        yield 'comparator overrides title (match)' => [
+            Item::create()->title('Display Title')->comparator('user/repo'),
+            'user',
+            true,
+        ];
+        yield 'comparator overrides title (no match against display)' => [
+            Item::create()->title('Display Title')->comparator('user/repo'),
+            'display',
+            false,
+        ];
+        yield 'prefix stripped from query (onlyTitle=false)' => [
+            Item::create()->title('repo')->prefix('gh ', false),
+            'gh repo',
+            true,
+        ];
+        yield 'prefix kept in query (onlyTitle=true)' => [
+            Item::create()->title('repo')->prefix('gh '),
+            'gh repo',
+            false,
+        ];
+    }
+
+    /**
+     * @param list<string> $titles
+     * @param list<string> $expectedOrder
+     */
+    #[DataProvider('dataMatchRankingOrder')]
+    public function testMatchRankingOrder(string $query, array $titles, array $expectedOrder): void
+    {
+        $items = [];
+        foreach ($titles as $title) {
+            $item = Item::create()->title($title);
+            self::assertTrue($item->match($query), "expected '$title' to match '$query'");
+            $items[] = $item;
+        }
+        usort($items, static fn (Item $a, Item $b) => $a->compare($b));
+
+        $titleProp = new ReflectionProperty(Item::class, 'title');
+        $sorted = array_map(static fn (Item $i) => (string) $titleProp->getValue($i), $items);
+        self::assertSame($expectedOrder, $sorted);
+    }
+
+    /** @return array<string, array{string, list<string>, list<string>}> */
+    public static function dataMatchRankingOrder(): array
+    {
+        return [
+            'consecutive prefix beats interspersed' => [
+                'user/r',
+                ['user/something-with-r-later', 'user/repo'],
+                ['user/repo', 'user/something-with-r-later'],
+            ],
+            'shorter title wins on equal sameChars' => [
+                'rep',
+                ['repository', 'repo'],
+                ['repo', 'repository'],
+            ],
+        ];
+    }
+
+    public function testCompareFallsBackToPrioWhenSameCharsEqual(): void
+    {
+        $high = Item::create()->title('alpha')->prio(10);
+        $low = Item::create()->title('alpha')->prio(1);
+
+        $high->match('a');
+        $low->match('a');
+
+        self::assertSame(-1, $high->compare($low));
+        self::assertSame(1, $low->compare($high));
+    }
+
+    public function testToXmlRendersTitleSubtitleAndIcon(): void
+    {
+        $item = Item::create()
+            ->title('Hello')
+            ->subtitle('World')
+            ->icon('file')
+            ->arg('https://example.com');
+
+        $xml = self::parseXml(Item::toXml([$item], false, false, null));
+
+        self::assertSame('Hello', (string) $xml->item[0]->title);
+        self::assertSame('World', (string) $xml->item[0]->subtitle);
+        self::assertSame('icons/file.png', (string) $xml->item[0]->icon);
+    }
+
+    public function testToXmlFallsBackToDefaultIconWhenFileMissing(): void
+    {
+        $item = Item::create()->title('Hello')->icon('does-not-exist');
+
+        $xml = self::parseXml(Item::toXml([$item], false, false, null));
+
+        self::assertSame('icon.png', (string) $xml->item[0]->icon);
+    }
+
+    public function testToXmlEscapesSpecialChars(): void
+    {
+        $item = Item::create()->title('A & B <c>')->subtitle('"q\'s"');
+
+        $raw = Item::toXml([$item], false, false, null);
+        self::assertIsString($raw);
+        self::assertStringContainsString('A &amp; B &lt;c&gt;', $raw);
+
+        $xml = self::parseXml($raw);
+        self::assertSame('A & B <c>', (string) $xml->item[0]->title);
+        self::assertSame('"q\'s"', (string) $xml->item[0]->subtitle);
+    }
+
+    #[DataProvider('dataToXmlArg')]
+    public function testToXmlArg(string $arg, bool $enterprise, ?string $baseUrl, string $expected): void
+    {
+        $item = Item::create()->title('t')->arg($arg);
+
+        $xml = self::parseXml(Item::toXml([$item], $enterprise, false, $baseUrl));
+
+        self::assertSame($expected, (string) $xml->item[0]['arg']);
+    }
+
+    /** @return iterable<string, array{string, bool, ?string, string}> */
+    public static function dataToXmlArg(): iterable
+    {
+        yield 'enterprise prefixes non-url' => ['> login', true, null, 'e > login'];
+        yield 'url passes through unchanged' => ['https://example.com', true, null, 'https://example.com'];
+        yield 'leading slash is expanded with baseUrl' => ['/user/repo', false, 'https://github.com', 'https://github.com/user/repo'];
+    }
+
+    public function testToXmlMarksInvalidItemAndAppendsAdd(): void
+    {
+        $item = Item::create()->title('search')->valid(false, ' …');
+
+        $xml = self::parseXml(Item::toXml([$item], false, false, null));
+
+        self::assertSame('no', (string) $xml->item[0]['valid']);
+        self::assertSame('search …', (string) $xml->item[0]->title);
+    }
+
+    #[DataProvider('dataToXmlAutocomplete')]
+    public function testToXmlAutocomplete(Item $item, bool $hotkey, ?string $expected): void
+    {
+        $xml = self::parseXml(Item::toXml([$item], false, $hotkey, null));
+
+        if (null === $expected) {
+            self::assertNull($xml->item[0]['autocomplete']);
+        } else {
+            self::assertSame($expected, (string) $xml->item[0]['autocomplete']);
+        }
+    }
+
+    /** @return iterable<string, array{Item, bool, ?string}> */
+    public static function dataToXmlAutocomplete(): iterable
+    {
+        yield 'title default with leading space (no hotkey)' => [
+            Item::create()->title('repo')->autocomplete(),
+            false,
+            ' repo',
+        ];
+        yield 'title default without space (hotkey)' => [
+            Item::create()->title('repo')->autocomplete(),
+            true,
+            'repo',
+        ];
+        yield 'comparator overrides title' => [
+            Item::create()->title('Display')->comparator('cmp')->autocomplete(),
+            true,
+            'cmp',
+        ];
+        yield 'explicit string wins over title' => [
+            Item::create()->title('Display')->autocomplete('forced'),
+            true,
+            'forced',
+        ];
+        yield 'prefix included when not onlyTitle' => [
+            Item::create()->title('repo')->prefix('gh ', false),
+            true,
+            'gh repo',
+        ];
+        yield 'autocomplete=false → no attribute' => [
+            Item::create()->title('repo')->autocomplete(false),
+            true,
+            null,
+        ];
+    }
+
+    public function testToXmlPrefixIsPrependedToTitle(): void
+    {
+        $item = Item::create()->title('repo')->prefix('gh ');
+
+        $xml = self::parseXml(Item::toXml([$item], false, false, null));
+
+        self::assertSame('gh repo', (string) $xml->item[0]->title);
+    }
+
+    public function testToXmlUid(): void
+    {
+        $a = Item::create()->title('repo');
+        $b = Item::create()->title('repo');
+        $random = Item::create()->title('repo')->randomUid();
+
+        $xmlA = self::parseXml(Item::toXml([$a], false, false, null));
+        $xmlB = self::parseXml(Item::toXml([$b], false, false, null));
+        $xmlR = self::parseXml(Item::toXml([$random], false, false, null));
+
+        self::assertSame(
+            (string) $xmlA->item[0]['uid'],
+            (string) $xmlB->item[0]['uid'],
+            'same title must produce identical uid',
+        );
+        self::assertNotSame(
+            (string) $xmlA->item[0]['uid'],
+            (string) $xmlR->item[0]['uid'],
+            'randomUid() must produce a different uid for the same title',
+        );
+    }
+
+    private static function parseXml(string|false $xml): SimpleXMLElement
+    {
+        self::assertIsString($xml);
+        $parsed = simplexml_load_string($xml);
+        self::assertInstanceOf(SimpleXMLElement::class, $parsed);
+
+        return $parsed;
+    }
+}

--- a/tests/WorkflowTest.php
+++ b/tests/WorkflowTest.php
@@ -1,0 +1,213 @@
+<?php
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class WorkflowTest extends TestCase
+{
+    private static string $tmpDir = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$tmpDir = sys_get_temp_dir() . '/agw-workflow-test-' . bin2hex(random_bytes(6));
+        mkdir(self::$tmpDir, 0o755, true);
+        putenv('alfred_workflow_data=' . self::$tmpDir);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::resetStaticState();
+
+        if (is_dir(self::$tmpDir)) {
+            $files = glob(self::$tmpDir . '/*') ?: [];
+            foreach ($files as $f) {
+                if (is_file($f)) {
+                    @unlink($f);
+                }
+            }
+            @rmdir(self::$tmpDir);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        self::reInit();
+        Workflow::getStatement('DELETE FROM config')->execute();
+        Workflow::deleteCache();
+    }
+
+    private static function resetStaticState(): void
+    {
+        foreach (['items', 'refreshUrls', 'statements'] as $name) {
+            $prop = new ReflectionProperty(Workflow::class, $name);
+            $prop->setValue(null, []);
+        }
+
+        // Workflow::init() only mutates the URL state inside the enterprise branch,
+        // never restores it. Reset to class defaults so iterations don't leak into each other.
+        foreach ([
+            'baseUrl' => 'https://github.com',
+            'apiUrl' => 'https://api.github.com',
+            'gistUrl' => 'https://gist.github.com',
+        ] as $name => $default) {
+            $prop = new ReflectionProperty(Workflow::class, $name);
+            $prop->setValue(null, $default);
+        }
+    }
+
+    /** Re-init Workflow after wiping state, so prepared statements bind to the freshly-created PDO. */
+    private static function reInit(bool $enterprise = false, ?string $query = null): void
+    {
+        self::resetStaticState();
+        Workflow::init(enterprise: $enterprise, query: $query);
+    }
+
+    #[DataProvider('dataGetApiUrl')]
+    public function testGetApiUrl(?string $path, string $expected): void
+    {
+        self::assertSame($expected, Workflow::getApiUrl($path));
+    }
+
+    /** @return iterable<string, array{?string, string}> */
+    public static function dataGetApiUrl(): iterable
+    {
+        yield 'no path returns base api url' => [null, 'https://api.github.com'];
+        yield 'path without query gets ?per_page=100' => ['/user', 'https://api.github.com/user?per_page=100'];
+        yield 'path with query gets &per_page=100' => ['/search?q=foo', 'https://api.github.com/search?q=foo&per_page=100'];
+    }
+
+    public function testAccessTokenIsScopedByEnterpriseMode(): void
+    {
+        Workflow::setAccessToken('user-token');
+        self::assertSame('user-token', Workflow::getAccessToken());
+        self::assertSame('user-token', Workflow::getConfig('access_token'));
+        self::assertNull(Workflow::getConfig('enterprise_access_token'));
+
+        // Switching to enterprise mode swaps the config key getAccessToken reads.
+        self::reInit(enterprise: true);
+        self::assertNull(Workflow::getAccessToken(), 'enterprise mode must not see the user token');
+
+        Workflow::setAccessToken('enterprise-token');
+        self::assertSame('enterprise-token', Workflow::getAccessToken());
+        self::assertSame('enterprise-token', Workflow::getConfig('enterprise_access_token'));
+        // Writes in enterprise mode must not touch the user token.
+        self::assertSame('user-token', Workflow::getConfig('access_token'));
+
+        // removeAccessToken targets the current mode's key only.
+        Workflow::removeAccessToken();
+        self::assertNull(Workflow::getAccessToken());
+        self::assertSame('user-token', Workflow::getConfig('access_token'));
+    }
+
+    #[DataProvider('dataGetConfigDefault')]
+    public function testGetConfigDefault(?string $stored, mixed $default, mixed $expected): void
+    {
+        if (null !== $stored) {
+            Workflow::setConfig('key', $stored);
+        }
+        self::assertSame($expected, Workflow::getConfig('key', $default));
+    }
+
+    /** @return iterable<string, array{?string, mixed, mixed}> */
+    public static function dataGetConfigDefault(): iterable
+    {
+        yield 'missing key returns null without default' => [null, null, null];
+        yield 'missing key returns the supplied default' => [null, 'fallback', 'fallback'];
+        yield 'present key wins over default' => ['stored', 'fallback', 'stored'];
+    }
+
+    public function testCleanCacheRemovesOnlyOldRows(): void
+    {
+        $now = time();
+        $oldUrl = 'https://example.com/old';
+        $recentUrl = 'https://example.com/recent';
+
+        $insert = Workflow::getStatement('REPLACE INTO request_cache VALUES(?, ?, ?, ?, 0, NULL)');
+        $insert->execute([$oldUrl, $now - 101 * 86400, null, '{}']);
+        $insert->execute([$recentUrl, $now - 99 * 86400, null, '{}']);
+
+        Workflow::cleanCache();
+
+        $stmt = Workflow::getStatement('SELECT url FROM request_cache ORDER BY url');
+        $stmt->execute();
+        $remaining = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        self::assertSame([$recentUrl], $remaining);
+    }
+
+    public function testAddItemIfMatchesFiltersByQuery(): void
+    {
+        self::reInit(query: 'foo');
+
+        Workflow::addItemIfMatches(Item::create()->title('foo'));
+        Workflow::addItemIfMatches(Item::create()->title('bar'));
+
+        $rendered = Workflow::getItemsAsXml();
+        self::assertIsString($rendered);
+        $xml = simplexml_load_string($rendered);
+        self::assertInstanceOf(SimpleXMLElement::class, $xml);
+
+        self::assertCount(1, $xml->item);
+        self::assertSame('foo', (string) $xml->item[0]->title);
+    }
+
+    #[DataProvider('dataInitEnterpriseUrls')]
+    public function testInitEnterpriseUrls(?string $enterpriseUrl, ?string $expectedBaseUrl, ?string $expectedApiUrl, ?string $expectedGistUrl): void
+    {
+        if (null !== $enterpriseUrl) {
+            Workflow::setConfig('enterprise_url', $enterpriseUrl);
+        }
+        self::reInit(enterprise: true);
+
+        self::assertSame($expectedBaseUrl, Workflow::getBaseUrl());
+        self::assertSame($expectedApiUrl, Workflow::getApiUrl());
+        self::assertSame($expectedGistUrl, Workflow::getGistUrl());
+    }
+
+    /** @return iterable<string, array{?string, ?string, ?string, ?string}> */
+    public static function dataInitEnterpriseUrls(): iterable
+    {
+        yield 'unset enterprise_url collapses URLs to null' => [null, null, null, null];
+        yield 'custom host derives api/gist subpaths' => [
+            'https://ghe.example.com',
+            'https://ghe.example.com',
+            'https://ghe.example.com/api/v3',
+            'https://ghe.example.com/gist',
+        ];
+        yield 'github.com /enterprises/<slug> keeps default URLs (cloud mode)' => [
+            'https://github.com/enterprises/foo',
+            'https://github.com',
+            'https://api.github.com',
+            'https://gist.github.com',
+        ];
+    }
+
+    #[DataProvider('dataCheckUpdate')]
+    public function testCheckUpdate(int $autoupdate, ?string $cachedTag, bool $expected): void
+    {
+        Workflow::setConfig('autoupdate', $autoupdate);
+
+        if (null !== $cachedTag) {
+            // Pre-populate the release endpoint so Fetcher serves from cache instead of
+            // hitting the real api.github.com.
+            Workflow::getStatement('REPLACE INTO request_cache VALUES(?, ?, ?, ?, 0, NULL)')
+                ->execute([
+                    'https://api.github.com/repos/gharlan/alfred-github-workflow/releases/latest',
+                    time(),
+                    null,
+                    json_encode(['tag_name' => $cachedTag]),
+                ]);
+        }
+
+        self::assertSame($expected, Workflow::checkUpdate());
+    }
+
+    /** @return iterable<string, array{int, ?string, bool}> */
+    public static function dataCheckUpdate(): iterable
+    {
+        yield 'autoupdate disabled never reports an update' => [0, null, false];
+        yield 'cached current version is not an update' => [1, 'v' . Workflow::VERSION, false];
+        yield 'cached older version is not an update' => [1, 'v0.0.1', false];
+        yield 'cached newer version is an update' => [1, 'v99.99.99', true];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/workflow.php';
+require_once __DIR__ . '/HttpServerTestCase.php';

--- a/tests/fixtures/curl-server.php
+++ b/tests/fixtures/curl-server.php
@@ -1,0 +1,54 @@
+<?php
+
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+
+switch ($path) {
+    case '/hello':
+        header('Content-Type: text/plain; charset=utf-8');
+        header('ETag: "etag-hello"');
+        header('Link: <https://example.com/next>; rel="next"');
+        echo 'Hello, World!';
+
+        return true;
+
+    case '/echo-headers':
+        header('Content-Type: application/json');
+        echo json_encode([
+            'authorization' => $_SERVER['HTTP_AUTHORIZATION'] ?? '',
+            'user-agent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
+            'x-url' => $_SERVER['HTTP_X_URL'] ?? '',
+        ]);
+
+        return true;
+
+    case '/etag':
+        header('ETag: "v1"');
+        if ('"v1"' === ($_SERVER['HTTP_IF_NONE_MATCH'] ?? '')) {
+            http_response_code(304);
+
+            return true;
+        }
+        header('Content-Type: text/plain');
+        echo 'fresh content';
+
+        return true;
+
+    case '/echo-id':
+        $id = $_GET['id'] ?? '';
+        header('Content-Type: text/plain');
+        // Light delay so parallel requests actually overlap.
+        usleep(20_000);
+        echo 'id-' . $id;
+
+        return true;
+
+    case '/server-error':
+        http_response_code(500);
+        echo 'boom';
+
+        return true;
+}
+
+http_response_code(404);
+
+return true;

--- a/tests/fixtures/curl-server.php
+++ b/tests/fixtures/curl-server.php
@@ -36,8 +36,6 @@ switch ($path) {
     case '/echo-id':
         $id = $_GET['id'] ?? '';
         header('Content-Type: text/plain');
-        // Delay so parallel requests have a clear sequential baseline to beat.
-        usleep(100_000);
         echo 'id-' . $id;
 
         return true;

--- a/tests/fixtures/curl-server.php
+++ b/tests/fixtures/curl-server.php
@@ -36,8 +36,8 @@ switch ($path) {
     case '/echo-id':
         $id = $_GET['id'] ?? '';
         header('Content-Type: text/plain');
-        // Light delay so parallel requests actually overlap.
-        usleep(20_000);
+        // Delay so parallel requests have a clear sequential baseline to beat.
+        usleep(100_000);
         echo 'id-' . $id;
 
         return true;

--- a/tests/fixtures/fetcher-server.php
+++ b/tests/fixtures/fetcher-server.php
@@ -1,0 +1,100 @@
+<?php
+
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+$baseUrl = 'http://' . ($_SERVER['HTTP_HOST'] ?? '127.0.0.1');
+
+$hitsFile = getenv('FETCHER_HITS_FILE');
+if ($hitsFile) {
+    file_put_contents($hitsFile, ($_SERVER['REQUEST_URI'] ?? '') . "\n", FILE_APPEND | LOCK_EX);
+}
+
+switch ($path) {
+    case '/json':
+        header('Content-Type: application/json');
+        $id = $_GET['id'] ?? '0';
+        echo json_encode(['id' => $id, 'value' => 'val-' . $id]);
+
+        return true;
+
+    case '/paginated':
+        // 3 pages of 2 items each, chained via Link: rel="next".
+        header('Content-Type: application/json');
+        $page = (int) ($_GET['p'] ?? 1);
+        $total = 3;
+        if ($page < $total) {
+            header('Link: <' . $baseUrl . '/paginated?p=' . ($page + 1) . '>; rel="next"');
+        }
+        echo json_encode([
+            ['page' => $page, 'item' => ($page - 1) * 2 + 1],
+            ['page' => $page, 'item' => ($page - 1) * 2 + 2],
+        ]);
+
+        return true;
+
+    case '/etag':
+        $value = $_GET['v'] ?? 'default';
+        $etag = '"' . $value . '"';
+        header('ETag: ' . $etag);
+        header('Content-Type: application/json');
+        if (($_SERVER['HTTP_IF_NONE_MATCH'] ?? '') === $etag) {
+            http_response_code(304);
+
+            return true;
+        }
+        echo json_encode(['value' => $value]);
+
+        return true;
+
+    case '/items-wrapper':
+        header('Content-Type: application/json');
+        echo json_encode([
+            'total_count' => 2,
+            'items' => [
+                ['name' => 'one'],
+                ['name' => 'two'],
+            ],
+        ]);
+
+        return true;
+
+    case '/picky':
+        // Rich object for the field-whitelist test.
+        header('Content-Type: application/json');
+        echo json_encode([
+            'sha' => 'abc',
+            'message' => 'msg',
+            'extra' => 'should-be-stripped',
+            'commit' => [
+                'message' => 'commit-msg',
+                'author' => [
+                    'name' => 'Alice',
+                    'date' => '2024-01-01',
+                ],
+            ],
+        ]);
+
+        return true;
+
+    case '/non-json':
+        header('Content-Type: text/plain');
+        echo 'Hello, World!';
+
+        return true;
+
+    case '/error500':
+        http_response_code(500);
+        echo 'boom';
+
+        return true;
+
+    case '/slow':
+        usleep(20_000);
+        header('Content-Type: application/json');
+        echo json_encode(['id' => $_GET['id'] ?? '']);
+
+        return true;
+}
+
+http_response_code(404);
+
+return true;

--- a/tests/fixtures/fetcher-server.php
+++ b/tests/fixtures/fetcher-server.php
@@ -88,7 +88,6 @@ switch ($path) {
         return true;
 
     case '/slow':
-        usleep(100_000);
         header('Content-Type: application/json');
         echo json_encode(['id' => $_GET['id'] ?? '']);
 

--- a/tests/fixtures/fetcher-server.php
+++ b/tests/fixtures/fetcher-server.php
@@ -88,7 +88,7 @@ switch ($path) {
         return true;
 
     case '/slow':
-        usleep(20_000);
+        usleep(100_000);
         header('Content-Type: application/json');
         echo json_encode(['id' => $_GET['id'] ?? '']);
 


### PR DESCRIPTION
## Summary
- Add PHPUnit ^11.5 (PHP 8.2 compatible) with `composer phpunit` script and `.cache/phpunit` cache dir
- Cover `Item`, `Curl`, `Fetcher` and `Workflow` — 73 tests, 199 assertions, all green; PHPStan clean
- Mix of pure unit tests (matching, ranking, header parsing, config scoping, version compare …) and integration tests against a local `php -S` test server (parallel execution, ETag/304, paginated cache chains, stale-while-revalidate, field whitelisting …)
- `HttpServerTestCase` abstracts server lifecycle (free port, spawn, ready-poll, teardown) so `CurlTest` and `FetcherTest` only declare the router fixture
- CI runs the suite on PHP 8.2 – 8.6 (matrix, `fail-fast: false`)
- Tiny prod nudge: `src/workflow.php` switches `require` → `require_once` so `tests/bootstrap.php` can load the file safely

## Test plan
- [x] `composer phpunit` — 73/73 green locally on PHP 8.5
- [x] `composer phpstan` — clean
- [x] `composer cs-fixer --dry-run` — clean
- [x] CI passes across PHP 8.2 – 8.6