### PR TITLE
Prioritise exact match on number when searching for issues

### DIFF
--- a/src/search.php
+++ b/src/search.php
@@ -416,6 +416,7 @@ final class Search
                         'number', 'title', 'html_url', 'updated_at',
                         'pull_request' => [],
                     ]));
+                    $numberQuery = filter_var(substr($parts[1], 1), FILTER_VALIDATE_INT);
                     foreach ($issues as $issue) {
                         Workflow::addItemIfMatches(Item::create()
                             ->title($issue->title)
@@ -423,7 +424,7 @@ final class Search
                             ->subtitle('#' . $issue->number)
                             ->icon(isset($issue->pull_request) ? 'pull-request' : 'issue')
                             ->arg($issue->html_url)
-                            ->prio(strtotime($issue->updated_at))
+                            ->prio($numberQuery && $issue->number === $numberQuery ? PHP_INT_MAX : strtotime($issue->updated_at))
                         );
                     }
                     break;


### PR DESCRIPTION
# Problem

Sometimes searching for an issue by number doesn't result in that issue being listed first.

For example:
<img width="613" height="512" alt="image" src="https://github.com/user-attachments/assets/452d4605-7854-413e-9793-bfeceec7a39a" />

This is annoying when looking for a specific issue which I do often when looking through the commit history / git blame.

# Solution

Give the issue with issue number matching the query highest priority so it sorts first (ignoring the learning / top result keyword latching stuff that alfred does).

<img width="591" height="494" alt="image" src="https://github.com/user-attachments/assets/e0aebd1d-04f2-43a6-8e7e-add0e46a3a8b" />