### PR TITLE
Use local, untyped variable for fetched user to check for success

### DIFF
--- a/src/search.php
+++ b/src/search.php
@@ -43,11 +43,12 @@ final class Search
             return;
         }
 
-        if (!Workflow::getAccessToken() || !(self::$user = Fetcher::requestApi('/user'))) {
+        if (!Workflow::getAccessToken() || !($fetchedUser = Fetcher::requestApi('/user'))) {
             self::addLoginCommands();
 
             return;
         }
+        self::$user = $fetchedUser;
 
         Workflow::stopServer();
 


### PR DESCRIPTION
Fixes #163, by avoiding assigning to the `stdClass $user` variable until after we know it succeeded.

I haven't written much PHP, but I think this is a reasonable approach to fix the type issue.

1. Continues to fetch the user API only once
2. Checks for success of the API using the pre-existing truthiness logic. If there's no user, it shows the login options and exits. For example, when the access token has expired.
3. If we have a truthy `$fetchedUser`, assigns it to the `self::$user` variable
